### PR TITLE
Add agents.sessions.setStatus and agents.sessions.rename

### DIFF
--- a/src/client/api-client.ts
+++ b/src/client/api-client.ts
@@ -94,6 +94,8 @@ import type {
   AdminWorkflowsPermissionsLookupRequest,
   AdminWorkflowsSearchRequest,
   AdminWorkflowsUnpublishRequest,
+  AgentsSessionsRenameRequest,
+  AgentsSessionsSetStatusRequest,
   AppsConnectionsOpenRequest,
   AppsDatastoreDeleteRequest,
   AppsDatastoreGetRequest,
@@ -562,6 +564,8 @@ import type {
   WorkflowsTriggersListResponse,
   WorkflowsTriggersUpdateResponse,
 } from "./automation-response/index";
+import type { AgentsSessionsRenameResponse } from "./custom-response/AgentsSessionsRenameResponse";
+import type { AgentsSessionsSetStatusResponse } from "./custom-response/AgentsSessionsSetStatusResponse";
 import type { FilesUploadV2Response } from "./custom-response/FilesUploadV2Response";
 import type { RetryHandler, RetryHandlerState } from "./retry-handler/index";
 import { RatelimitRetryHandler } from "./retry-handler/index";
@@ -1200,6 +1204,13 @@ export class SlackAPIClient {
           "admin.workflows.permissions.lookup",
         ),
       },
+    },
+  };
+
+  public readonly agents = {
+    sessions: {
+      setStatus: this.#bindApiCall<AgentsSessionsSetStatusRequest, AgentsSessionsSetStatusResponse>(this, "agents.sessions.setStatus"),
+      rename: this.#bindApiCall<AgentsSessionsRenameRequest, AgentsSessionsRenameResponse>(this, "agents.sessions.rename"),
     },
   };
 

--- a/src/client/custom-response/AgentsSessionsRenameResponse.ts
+++ b/src/client/custom-response/AgentsSessionsRenameResponse.ts
@@ -1,0 +1,12 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export type AgentsSessionsRenameResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  needed?: string;
+  provided?: string;
+
+  title?: string;
+};

--- a/src/client/custom-response/AgentsSessionsSetStatusResponse.ts
+++ b/src/client/custom-response/AgentsSessionsSetStatusResponse.ts
@@ -1,0 +1,18 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response";
+
+export type AgentSessionStatus = "active" | "processing" | "suspended" | "closed";
+
+export type AgentsSessionsSetStatusResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  needed?: string;
+  provided?: string;
+
+  /** Session-wide status across every agent present, with precedence suspended > processing > active > closed. */
+  status?: AgentSessionStatus;
+  /** The calling agent's own status, the value this call just wrote. */
+  agent_status?: AgentSessionStatus;
+  title?: string;
+};

--- a/src/client/request.ts
+++ b/src/client/request.ts
@@ -479,6 +479,34 @@ export interface AdminWorkflowsUnpublishRequest extends SlackAPIRequest {
 }
 
 /*
+ * `agents.*`
+ */
+
+export interface AgentsSessionsSetStatusRequest extends SlackAPIRequest {
+  channel_id: string;
+  status: "active" | "processing" | "suspended" | "closed";
+  /** Required for thread-based sessions; must be omitted for session channels. */
+  thread_ts?: string;
+  /** Up to 200 characters. Applied only when the session is created; use `agents.sessions.rename` afterwards. */
+  title?: string;
+  /** Honored only when the session is created. The user must be a member of the channel. */
+  initiator_user_id?: string;
+  /** Requires the `chat:write.customize` scope. Takes priority over `icon_url`. */
+  icon_emoji?: string;
+  /** Requires the `chat:write.customize` scope. */
+  icon_url?: string;
+  /** Requires the `chat:write.customize` scope. Up to 200 characters. */
+  username?: string;
+}
+export interface AgentsSessionsRenameRequest extends SlackAPIRequest {
+  channel_id: string;
+  /** 1-200 characters. Renames the channel too when the session is a session channel. */
+  title: string;
+  /** Required for thread-based sessions; must be omitted for session channels. */
+  thread_ts?: string;
+}
+
+/*
  * `api.*`
  */
 export type APITestRequest = SlackAPIRequest;

--- a/src/manifest/events.ts
+++ b/src/manifest/events.ts
@@ -1,6 +1,7 @@
 // https://api.slack.com/events?filter=Events
 // var events = [].slice.call(document.getElementsByClassName('apiReferenceFilterableList__listItemLink')).map(e => '"' + e.innerText + '"').join(' | '); console.log("export type AnyManifestEvent = Exclude<" + events + ", 'app_rate_limited'>;");
 export type AnyManifestEvent = Exclude<
+  | "agent_session_stopped"
   | "app_context_changed"
   | "app_deleted"
   | "app_home_opened"

--- a/src_deno/client/api-client.ts
+++ b/src_deno/client/api-client.ts
@@ -96,6 +96,8 @@ import type {
   AdminWorkflowsPermissionsLookupRequest,
   AdminWorkflowsSearchRequest,
   AdminWorkflowsUnpublishRequest,
+  AgentsSessionsRenameRequest,
+  AgentsSessionsSetStatusRequest,
   APITestRequest,
   AppsConnectionsOpenRequest,
   AppsDatastoreDeleteRequest,
@@ -562,6 +564,8 @@ import type {
   WorkflowsTriggersListResponse,
   WorkflowsTriggersUpdateResponse,
 } from "./automation-response/index.ts";
+import type { AgentsSessionsRenameResponse } from "./custom-response/AgentsSessionsRenameResponse.ts";
+import type { AgentsSessionsSetStatusResponse } from "./custom-response/AgentsSessionsSetStatusResponse.ts";
 import type { FilesUploadV2Response } from "./custom-response/FilesUploadV2Response.ts";
 import type { RetryHandler, RetryHandlerState } from "./retry-handler/index.ts";
 import { RatelimitRetryHandler } from "./retry-handler/index.ts";
@@ -1554,6 +1558,19 @@ export class SlackAPIClient {
           "admin.workflows.permissions.lookup",
         ),
       },
+    },
+  };
+
+  public readonly agents = {
+    sessions: {
+      setStatus: this.#bindApiCall<
+        AgentsSessionsSetStatusRequest,
+        AgentsSessionsSetStatusResponse
+      >(this, "agents.sessions.setStatus"),
+      rename: this.#bindApiCall<
+        AgentsSessionsRenameRequest,
+        AgentsSessionsRenameResponse
+      >(this, "agents.sessions.rename"),
     },
   };
 

--- a/src_deno/client/custom-response/AgentsSessionsRenameResponse.ts
+++ b/src_deno/client/custom-response/AgentsSessionsRenameResponse.ts
@@ -1,0 +1,12 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export type AgentsSessionsRenameResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  needed?: string;
+  provided?: string;
+
+  title?: string;
+};

--- a/src_deno/client/custom-response/AgentsSessionsSetStatusResponse.ts
+++ b/src_deno/client/custom-response/AgentsSessionsSetStatusResponse.ts
@@ -1,0 +1,22 @@
+// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-empty-interface
+
+import type { SlackAPIResponse } from "../response.ts";
+
+export type AgentSessionStatus =
+  | "active"
+  | "processing"
+  | "suspended"
+  | "closed";
+
+export type AgentsSessionsSetStatusResponse = SlackAPIResponse & {
+  ok: boolean;
+  error?: string;
+  needed?: string;
+  provided?: string;
+
+  /** Session-wide status across every agent present, with precedence suspended > processing > active > closed. */
+  status?: AgentSessionStatus;
+  /** The calling agent's own status, the value this call just wrote. */
+  agent_status?: AgentSessionStatus;
+  title?: string;
+};

--- a/src_deno/client/request.ts
+++ b/src_deno/client/request.ts
@@ -526,6 +526,34 @@ export interface AdminWorkflowsUnpublishRequest extends SlackAPIRequest {
 }
 
 /*
+ * `agents.*`
+ */
+
+export interface AgentsSessionsSetStatusRequest extends SlackAPIRequest {
+  channel_id: string;
+  status: "active" | "processing" | "suspended" | "closed";
+  /** Required for thread-based sessions; must be omitted for session channels. */
+  thread_ts?: string;
+  /** Up to 200 characters. Applied only when the session is created; use `agents.sessions.rename` afterwards. */
+  title?: string;
+  /** Honored only when the session is created. The user must be a member of the channel. */
+  initiator_user_id?: string;
+  /** Requires the `chat:write.customize` scope. Takes priority over `icon_url`. */
+  icon_emoji?: string;
+  /** Requires the `chat:write.customize` scope. */
+  icon_url?: string;
+  /** Requires the `chat:write.customize` scope. Up to 200 characters. */
+  username?: string;
+}
+export interface AgentsSessionsRenameRequest extends SlackAPIRequest {
+  channel_id: string;
+  /** 1-200 characters. Renames the channel too when the session is a session channel. */
+  title: string;
+  /** Required for thread-based sessions; must be omitted for session channels. */
+  thread_ts?: string;
+}
+
+/*
  * `api.*`
  */
 export type APITestRequest = SlackAPIRequest;

--- a/src_deno/manifest/events.ts
+++ b/src_deno/manifest/events.ts
@@ -1,6 +1,7 @@
 // https://api.slack.com/events?filter=Events
 // var events = [].slice.call(document.getElementsByClassName('apiReferenceFilterableList__listItemLink')).map(e => '"' + e.innerText + '"').join(' | '); console.log("export type AnyManifestEvent = Exclude<" + events + ", 'app_rate_limited'>;");
 export type AnyManifestEvent = Exclude<
+  | "agent_session_stopped"
   | "app_context_changed"
   | "app_deleted"
   | "app_home_opened"


### PR DESCRIPTION
Slack's [2026-08-20 agent updates](https://docs.slack.dev/changelog/2026/08/20/agent-updates/) introduce the Agent Sessions API as the successor to `assistant.threads.*`, ahead of the `assistant_view` deprecation in February 2027:

| Legacy | Replacement |
|---|---|
| `assistant.threads.setStatus` | [`agents.sessions.setStatus`](https://docs.slack.dev/reference/methods/agents.sessions.setStatus) |
| `assistant.threads.setTitle` | [`agents.sessions.rename`](https://docs.slack.dev/reference/methods/agents.sessions.rename) |

A compatibility bridge keeps the legacy calls working, so this is additive — nothing existing changes.

Related: slack-edge/slack-edge#87, which tracks the broader `agent_view` migration.

### Changes

- `src/client/request.ts` — `AgentsSessionsSetStatusRequest` and `AgentsSessionsRenameRequest`, in a new `agents.*` section. `status` is typed as `"active" | "processing" | "suspended" | "closed"` since the reference enumerates exactly those.
- `src/client/custom-response/` — `AgentsSessionsSetStatusResponse` and `AgentsSessionsRenameResponse`, plus an exported `AgentSessionStatus` alias.
- `src/client/api-client.ts` — the `agents` namespace, ordered between `admin` and `api`.
- `src/manifest/events.ts` — `agent_session_stopped` added to `AnyManifestEvent`.
- `src_deno/` — regenerated via `scripts/generate-deno-source.sh`, not hand-edited.

### Why the responses are hand-written

`scripts/generate-api-client-responses.sh` derives `generated-response/` from java-slack-sdk fixtures, and the Java SDK does not cover `agents.sessions.*` yet. Following the convention in #64, payload-bearing responses go in `custom-response/`. They can move to `generated-response/` on a later regeneration once the Java SDK catches up.

Note that `setStatus` returns both `status` (session-wide, computed across every agent present, precedence `suspended` > `processing` > `active` > `closed`) and `agent_status` (the calling agent's own value). The reference notes these can diverge in multi-agent sessions, so both are modelled.

Following the `FilesUploadV2Response` precedent, the new response types are not re-exported from `src/index.ts`. Happy to add them if you'd prefer the public surface.

### Verification

- `npm run format` (biome) — clean
- `npx tsc --noEmit` — clean
- `npx vitest run` — 41/41 passing
- `deno check` via the deno source generator — clean, no formatting drift absorbed

Types are modelled from the published method references; I have not exercised the endpoints against a live workspace.
